### PR TITLE
Version pinning for PSSQLite

### DIFF
--- a/.github/workflows/PublishToGallery.ps1
+++ b/.github/workflows/PublishToGallery.ps1
@@ -1,6 +1,6 @@
 try{
     Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
-    Install-Module -Name 'PSSQLite' -Force -SkipPublisherCheck
+    Install-Module -Name 'PSSQLite' -Force -SkipPublisherCheck -RequiredVersion '1.1'
     Publish-Module -Path ".\UofIDMI" -Repository PSGallery -NuGetApiKey $ENV:NuGetApiKey -Force
 }
 catch{

--- a/.github/workflows/pester.yml
+++ b/.github/workflows/pester.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Install dependencies
-      run: Install-Module -Name 'PSSQLite' -Force -SkipPublisherCheck; Install-Module -Name 'Pester' -Force -SkipPublisherCheck -RequiredVersion '4.10.1'
+      run: Install-Module -Name 'PSSQLite' -Force -SkipPublisherCheck -RequiredVersion '1.1'; Install-Module -Name 'Pester' -Force -SkipPublisherCheck -RequiredVersion '4.10.1'
       shell: pwsh
     - name: Run tests
       run: Invoke-Pester -Path './tests' -EnableExit -ErrorAction Stop

--- a/UofIDMI/UofIDMI.psd1
+++ b/UofIDMI/UofIDMI.psd1
@@ -12,7 +12,7 @@
 RootModule = 'UofIDMI.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.3.0'
+ModuleVersion = '1.3.1'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -51,7 +51,7 @@ PowerShellVersion = '7.0.0'
 # ProcessorArchitecture = ''
 
 # Modules that must be imported into the global environment prior to importing this module
-RequiredModules = @('PSSQLite')
+RequiredModules = @("MyModule", @{ModuleName="PSSQLite"; ModuleVersion="1.1"; GUID="381f3394-9b8a-492e-94b4-b3aa9e775761"})
 
 # Assemblies that must be loaded prior to importing this module
 # RequiredAssemblies = @()

--- a/UofIDMI/UofIDMI.psd1
+++ b/UofIDMI/UofIDMI.psd1
@@ -51,7 +51,7 @@ PowerShellVersion = '7.0.0'
 # ProcessorArchitecture = ''
 
 # Modules that must be imported into the global environment prior to importing this module
-RequiredModules = @("MyModule", @{ModuleName="PSSQLite"; ModuleVersion="1.1"; GUID="381f3394-9b8a-492e-94b4-b3aa9e775761"})
+RequiredModules = @(@{ModuleName="PSSQLite"; ModuleVersion="1.1"; GUID="381f3394-9b8a-492e-94b4-b3aa9e775761"})
 
 # Assemblies that must be loaded prior to importing this module
 # RequiredAssemblies = @()


### PR DESCRIPTION
Pinned the PSSQLite version to 1.1 where applicable.

Potential fix for https://github.com/techservicesillinois/SecOps-PowerShell-DMI/issues/33